### PR TITLE
Add .exe files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cover.cov
 # Built binaries.
 DLiteScript
 output/
+*.exe


### PR DESCRIPTION
This PR adds the `.exe` file format to the `.gitignore` file